### PR TITLE
Remove ifc propertysets from default export config

### DIFF
--- a/BsddRevitPlugin.Common/Commands/IFCexporter.cs
+++ b/BsddRevitPlugin.Common/Commands/IFCexporter.cs
@@ -1,16 +1,15 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
-using Autodesk.Revit.DB.ExtensibleStorage;
 using Autodesk.Revit.UI;
 using BIM.IFC.Export.UI;
 using BsddRevitPlugin.Logic.IfcExport;
 using BsddRevitPlugin.Logic.Model;
+using BsddRevitPlugin.Logic.UI.BsddBridge;
+using BsddRevitPlugin.Logic.UI.Translations;
 using NLog;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Web.Script.Serialization;
 using System.Windows.Forms;
 using Document = Autodesk.Revit.DB.Document;
 using SaveFileDialog = System.Windows.Forms.SaveFileDialog;
@@ -300,6 +299,30 @@ namespace BsddRevitPlugin.Common.Commands
 
                     bsddIFCExportConfiguration.ExportUserDefinedPsets = true;
                     bsddIFCExportConfiguration.ExportUserDefinedPsetsFileName = tempFilePath;
+
+                    //Set the ExportIFCCommonPropertySets to false, so it doesn't interfere with the user defined IFC property sets added by the BSDD plugin
+
+                    LanguageConverter languageConverter = new LanguageConverter();
+                    string currentLanguage = GlobalBsddSettings.bsddsettings.Language;
+
+                    if (bsddIFCExportConfiguration.ExportIFCCommonPropertySets == true)
+                    {
+                        TaskDialog dialog = new TaskDialog(languageConverter.Translate("IFCExport_TaskDialogName", currentLanguage));
+                        dialog.MainInstruction = languageConverter.Translate("IFCExport_TaskDialogMessage", currentLanguage);
+
+                        dialog.CommonButtons = TaskDialogCommonButtons.Yes | TaskDialogCommonButtons.No;
+
+                        TaskDialogResult result = dialog.Show();
+
+                        if (result == TaskDialogResult.Yes)
+                        {
+                            bsddIFCExportConfiguration.ExportIFCCommonPropertySets = false;
+                        }
+                        else if (result == TaskDialogResult.No)
+                        {
+                            // User pressed 'No'
+                        }
+                    }
 
                     //Pass the setting of the myIFCExportConfiguration to the IFCExportOptions
                     bsddIFCExportConfiguration.UpdateOptions(ifcExportOptions, activeViewId);

--- a/BsddRevitPlugin.Logic/BsddRevitPlugin.Logic.csproj
+++ b/BsddRevitPlugin.Logic/BsddRevitPlugin.Logic.csproj
@@ -146,6 +146,7 @@
     <Compile Include="UI\Services\IBrowserService.cs" />
     <Compile Include="UI\Services\IBrowserServiceFactory.cs" />
     <Compile Include="UI\Services\ICustomBrowserControl.cs" />
+    <Compile Include="UI\Translations\LanguageConverter.cs" />
     <Compile Include="UI\View\BsddSelection.xaml.cs">
       <DependentUpon>BsddSelection.xaml</DependentUpon>
     </Compile>

--- a/BsddRevitPlugin.Logic/Model/IfcExportManager.cs
+++ b/BsddRevitPlugin.Logic/Model/IfcExportManager.cs
@@ -197,7 +197,7 @@ namespace BsddRevitPlugin.Logic.Model
 
             //Property Sets
             configuration.ExportInternalRevitPropertySets = false;
-            configuration.ExportIFCCommonPropertySets = true;
+            configuration.ExportIFCCommonPropertySets = false;
             configuration.ExportBaseQuantities = true;
             //configuration material prop sets
             configuration.ExportSchedulesAsPsets = false;

--- a/BsddRevitPlugin.Logic/UI/Translations/LanguageConverter.cs
+++ b/BsddRevitPlugin.Logic/UI/Translations/LanguageConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BsddRevitPlugin.Logic.UI.Translations
+{
+    public class LanguageConverter
+    {
+        public string Translate(string textParam, string language)
+        {
+            switch (language)
+            {
+                case "EN":
+                    return new English().GetType().GetProperty(textParam)?.GetValue(new English()).ToString();
+                case "nl-NL":
+                    return new Dutch().GetType().GetProperty(textParam)?.GetValue(new Dutch()).ToString();
+                default:
+                    new Exception("Language not supported");
+                    return new English().GetType().GetProperty(textParam)?.GetValue(new English()).ToString();
+            }
+        }
+    }
+    public class Dutch
+    {
+        public string IFCExport_TaskDialogName { get; } = "IFC Common Property Sets";
+        public string IFCExport_TaskDialogMessage { get; } = "IFC Common Property Sets (PSets) staan aan in de exportinstellingen. Dit kan conflicten geven met de IFC Psets die zijn toegevoegd door de bSDD plugin. Wij adviseren de Revit IFC PSets te deactiveren. \r\r Wil je deze direct uitzetten voor deze export?";
+    }
+
+    public class English
+    {
+        public string IFCExport_TaskDialogName { get; } = "IFC Common Property Sets";
+        public string IFCExport_TaskDialogMessage { get; } = "IFC Common Property Sets (PSets) were enabled. This can interfere with the IFC PSets added by the bSDD plugin. We advise you to disable the Revits IFC PSets. \r\r Would you like to disable this right now for this export?";
+    }
+
+}


### PR DESCRIPTION
Remove default export option ExportIFCCommonPropertySets because it conflicts with our bSDD IFC properties.